### PR TITLE
Adapt app packaging to imagej-launcher changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,59 +334,43 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 											<outputDirectory>${project.build.directory}/</outputDirectory>
 											<destFileName>imagej-launcher-${imagej-launcher.version}.jar</destFileName>
 										</artifactItem>
-									</artifactItems>
-								</configuration>
-							</execution>
-							<execution>
-								<id>unpack</id>
-								<phase>prepare-package</phase>
-								<goals>
-									<goal>unpack</goal>
-								</goals>
-								<configuration>
-									<artifactItems>
 										<artifactItem>
 											<groupId>${project.groupId}</groupId>
 											<artifactId>imagej-launcher</artifactId>
 											<version>${imagej-launcher.version}</version>
-											<classifier>amd64-Linux-gcc-executable</classifier>
-											<type>nar</type>
+											<classifier>linux64</classifier>
+											<type>exe</type>
 											<outputDirectory>${project.build.directory}/</outputDirectory>
+											<destFileName>imagej-launcher-linux64</destFileName>
 										</artifactItem>
 										<artifactItem>
 											<groupId>${project.groupId}</groupId>
 											<artifactId>imagej-launcher</artifactId>
 											<version>${imagej-launcher.version}</version>
-											<classifier>i386-Linux-gcc-executable</classifier>
-											<type>nar</type>
+											<classifier>win32</classifier>
+											<type>exe</type>
 											<outputDirectory>${project.build.directory}/</outputDirectory>
+											<destFileName>imagej-launcher-win32.exe</destFileName>
 										</artifactItem>
 										<artifactItem>
 											<groupId>${project.groupId}</groupId>
 											<artifactId>imagej-launcher</artifactId>
 											<version>${imagej-launcher.version}</version>
-											<classifier>amd64-Windows-gcc-executable</classifier>
-											<type>nar</type>
+											<classifier>win64</classifier>
+											<type>exe</type>
 											<outputDirectory>${project.build.directory}/</outputDirectory>
+											<destFileName>imagej-launcher-win64.exe</destFileName>
 										</artifactItem>
 										<artifactItem>
 											<groupId>${project.groupId}</groupId>
 											<artifactId>imagej-launcher</artifactId>
 											<version>${imagej-launcher.version}</version>
-											<classifier>x86-Windows-gcc-executable</classifier>
-											<type>nar</type>
+											<classifier>macosx</classifier>
+											<type>exe</type>
 											<outputDirectory>${project.build.directory}/</outputDirectory>
-										</artifactItem>
-										<artifactItem>
-											<groupId>${project.groupId}</groupId>
-											<artifactId>imagej-launcher</artifactId>
-											<version>${imagej-launcher.version}</version>
-											<classifier>x86_64-MacOSX-gcc-executable</classifier>
-											<type>nar</type>
-											<outputDirectory>${project.build.directory}/</outputDirectory>
+											<destFileName>imagej-launcher-macosx</destFileName>
 										</artifactItem>
 									</artifactItems>
-									<overWriteSnapshots>true</overWriteSnapshots>
 								</configuration>
 							</execution>
 						</executions>

--- a/src/main/assembly/application.xml
+++ b/src/main/assembly/application.xml
@@ -90,28 +90,23 @@
 			<destName>imagej-launcher-${imagej-launcher.version}.jar</destName>
 		</file>
 		<file>
-			<source>target/bin/i386-Linux-gcc/imagej-launcher</source>
-			<destName>ImageJ-linux32</destName>
-			<fileMode>0755</fileMode>
-		</file>
-		<file>
-			<source>target/bin/amd64-Linux-gcc/imagej-launcher</source>
+			<source>target/imagej-launcher-linux64</source>
 			<destName>ImageJ-linux64</destName>
 			<fileMode>0755</fileMode>
 		</file>
 		<file>
-			<source>target/bin/x86_64-MacOSX-gcc/imagej-launcher</source>
+			<source>target/imagej-launcher-macosx</source>
 			<outputDirectory>/Contents/MacOS/</outputDirectory>
 			<destName>ImageJ-macosx</destName>
 			<fileMode>0755</fileMode>
 		</file>
 		<file>
-			<source>target/bin/x86-Windows-gcc/imagej-launcher.exe</source>
+			<source>target/imagej-launcher-win32.exe</source>
 			<destName>ImageJ-win32.exe</destName>
 			<fileMode>0755</fileMode>
 		</file>
 		<file>
-			<source>target/bin/amd64-Windows-gcc/imagej-launcher.exe</source>
+			<source>target/imagej-launcher-win64.exe</source>
 			<destName>ImageJ-win64.exe</destName>
 			<fileMode>0755</fileMode>
 		</file>


### PR DESCRIPTION
Recently (starting with `imagej-launcher-5.0.0`), we have deprecated NAR packaging of the various launchers. This PR removes the superfluous unpacking step of executables from NARs.

Fixes #204.