### PR TITLE
Add imagej-plugins-batch runtime dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>23.1.0</version>
+		<version>23.2.0</version>
 		<relativePath />
 	</parent>
 
@@ -142,6 +142,11 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 			<artifactId>imagej-legacy</artifactId>
 			<scope>runtime</scope>
 			<optional>true</optional>
+		</dependency>
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-plugins-batch</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>net.imagej</groupId>


### PR DESCRIPTION
This should make sure that the `imagej-plugins-batch` component is uploaded to the update site by automatic tooling.
