### PR TITLE
Fix Roi setIntBounds widths

### DIFF
--- a/ij/gui/Roi.java
+++ b/ij/gui/Roi.java
@@ -518,8 +518,8 @@ public class Roi extends Object implements Cloneable, java.io.Serializable, Iter
 		if (useLineSubpixelConvention()) { //for PointRois & open lines, ensure the 'draw' area is enclosed
 			x = (int)Math.floor(bounds.x + 0.5);
 			y = (int)Math.floor(bounds.y + 0.5);
-			width  = (int)Math.floor(bounds.x + bounds.width + 1.5)  - x;
-			height = (int)Math.floor(bounds.y + bounds.height + 1.5) - y;
+			width  = (int)Math.floor(bounds.x + bounds.width + 1)  - x;
+			height = (int)Math.floor(bounds.y + bounds.height + 1) - y;
 		} else {                           //for area Rois, the subpixel bounds must be enclosed in the int bounds
 			x = (int)Math.floor(bounds.x);
 			y = (int)Math.floor(bounds.y);


### PR DESCRIPTION
Correct int bound width/height when the double bound ends in a decimal value >= 0.5