### PR TITLE
Add support for Zarr and N5 in DragAndDrop

### DIFF
--- a/ij/io/Opener.java
+++ b/ij/io/Opener.java
@@ -113,7 +113,7 @@ public class Opener {
 			else
 				imp.show(getLoadRate(start,imp));
 		} else {
-			if (isDirectory)
+			if (this.fileType != CUSTOM && isDirectory)
 				this.fileType = UNKNOWN;
 			switch (this.fileType) {
 				case LUT:

--- a/ij/plugin/DragAndDrop.java
+++ b/ij/plugin/DragAndDrop.java
@@ -175,7 +175,7 @@ public class DragAndDrop implements PlugIn, DropTargetListener, Runnable {
 			if (null == f) return;
 			String path = f.getCanonicalPath();
 			if (f.exists()) {
-				if (f.isDirectory() && !(new File(path, ".zgroup").exists()||new File(path, ".zarray").exists())) {
+				if (f.isDirectory() && !(new File(path, ".zgroup").exists()||new File(path, ".zarray").exists()||path.endsWith(".n5"))) {
 					if (openAsVirtualStack)
 						IJ.run("Image Sequence...", "open=[" + path + "] sort use");
 					else

--- a/ij/plugin/DragAndDrop.java
+++ b/ij/plugin/DragAndDrop.java
@@ -175,7 +175,7 @@ public class DragAndDrop implements PlugIn, DropTargetListener, Runnable {
 			if (null == f) return;
 			String path = f.getCanonicalPath();
 			if (f.exists()) {
-				if (f.isDirectory()) {
+				if (f.isDirectory() && !(new File(path, ".zgroup").exists()||new File(path, ".zarray").exists())) {
 					if (openAsVirtualStack)
 						IJ.run("Image Sequence...", "open=[" + path + "] sort use");
 					else


### PR DESCRIPTION
This PR adds exclusion rules for drag-and-drop of directories to support Zarr and N5 formats.
With this change, directories that comply with the following conditions are recognised as Zarr or N5 and its processing is delegated to a custom Opener provided by the plugin.

- Zarr: directories that contain `.zgroup` or `.zarray`
- N5: directories that end with `.n5`

Here is a demo how it works with Zarr (https://github.com/xulman/ome-zarr-fiji-ui).
![DnD](https://user-images.githubusercontent.com/36190671/190430183-99e5d7d3-9926-4886-ad5b-824369a9e14c.gif)

This is a result of collective work of several people noted below, during the **Fiji and Zarr hackathon 2022 in Prague, CZE**, which was generously supported by the [IT4Innovations National Supercomputing Centre, Ostrava, CZE](https://www.it4i.cz/en):

- [forum.sc link](https://forum.image.sc/t/fiji-ngff-hackathon-sep-2022-prague-cze/69191),
- [zulip link](https://imagesc.zulipchat.com/#narrow/stream/329366-Zzz.3A-.5B2022-09.5D-Fiji.2BNGFF-Prague-hackathon),
- [link at IT4I](https://events.it4i.cz/event/145/).

The people on-site during the hackathon:
**Ko Sugawara, Nils Norlin, Tobias Pietzsch, Christian Tischer, Vladimir Ulman**

The people online during the hackathon:
**Gabor Kovacs, Isaac Virshup, Luca Marconato, John Bogovic, Josh Moore**