### PR TITLE
Toggle overlay option

### DIFF
--- a/IJ_Props.txt
+++ b/IJ_Props.txt
@@ -216,14 +216,15 @@ overlay01="Add Selection...[b]",ij.plugin.OverlayCommands("add")
 overlay02="Add Image...",ij.plugin.OverlayCommands("image")
 overlay03="Hide Overlay",ij.plugin.OverlayCommands("hide")
 overlay04="Show Overlay",ij.plugin.OverlayCommands("show")
-overlay05="From ROI Manager",ij.plugin.OverlayCommands("from")
-overlay06="To ROI Manager",ij.plugin.OverlayCommands("to")
-overlay07="Remove Overlay",ij.plugin.OverlayCommands("remove")
-overlay08="List Elements",ij.plugin.OverlayCommands("list")
-overlay09="Flatten[F]",ij.plugin.OverlayCommands("flatten")
-overlay10="Labels...",ij.plugin.OverlayLabels
-overlay11="Measure Overlay",ij.plugin.OverlayCommands("measure")
-overlay12="Overlay Options...[Y]",ij.plugin.OverlayCommands("options")
+overlay05="Toggle Overlay[q]",ij.plugin.OverlayCommands("toggle")
+overlay06="From ROI Manager",ij.plugin.OverlayCommands("from")
+overlay07="To ROI Manager",ij.plugin.OverlayCommands("to")
+overlay08="Remove Overlay",ij.plugin.OverlayCommands("remove")
+overlay09="List Elements",ij.plugin.OverlayCommands("list")
+overlay10="Flatten[F]",ij.plugin.OverlayCommands("flatten")
+overlay11="Labels...",ij.plugin.OverlayLabels
+overlay12="Measure Overlay",ij.plugin.OverlayCommands("measure")
+overlay13="Overlay Options...[Y]",ij.plugin.OverlayCommands("options")
 
 # Plugins installed in the Image/Lookup Tables submenu
 lookup01="Invert LUT",ij.plugin.LutLoader("invert")

--- a/ij/plugin/OverlayCommands.java
+++ b/ij/plugin/OverlayCommands.java
@@ -36,6 +36,8 @@ public class OverlayCommands implements PlugIn {
 			hide();
 		else if (arg.equals("show"))
 			show();
+		else if (arg.equals("toggle"))
+			toggle();
 		else if (arg.equals("remove"))
 			remove();
 		else if (arg.equals("from"))
@@ -279,6 +281,11 @@ public class OverlayCommands implements PlugIn {
 				rm.runCommand("show all with labels");
 			}
 		}
+	}
+
+	void toggle() {
+		ImagePlus imp = IJ.getImage();
+		imp.setHideOverlay(!imp.getHideOverlay());
 	}
 
 	void remove() {


### PR DESCRIPTION
Added a menu item (Image > Overlay > Toggle Overlay), which toggles between showing and hiding overlays on the active image.  I've set this to keyboard shortcut Ctrl+Q as that didn't appear to be bound to anything else.