### PR TITLE
10 bit tiff support

### DIFF
--- a/ij/io/FileInfo.java
+++ b/ij/io/FileInfo.java
@@ -9,66 +9,69 @@ public class FileInfo implements Cloneable {
 
 	/** 8-bit unsigned integer (0-255). */
 	public static final int GRAY8 = 0;
-	
+
 	/**	16-bit signed integer (-32768-32767). Imported signed images
 		are converted to unsigned by adding 32768. */
 	public static final int GRAY16_SIGNED = 1;
-	
+
 	/** 16-bit unsigned integer (0-65535). */
 	public static final int GRAY16_UNSIGNED = 2;
-	
+
 	/**	32-bit signed integer. Imported 32-bit integer images are
 		converted to floating-point. */
 	public static final int GRAY32_INT = 3;
-	
+
 	/** 32-bit floating-point. */
 	public static final int GRAY32_FLOAT = 4;
-	
+
 	/** 8-bit unsigned integer with color lookup table. */
 	public static final int COLOR8 = 5;
-	
+
 	/** 24-bit interleaved RGB. Import/export only. */
-	public static final int RGB = 6;	
-	
+	public static final int RGB = 6;
+
 	/** 24-bit planer RGB. Import only. */
 	public static final int RGB_PLANAR = 7;
-	
+
 	/** 1-bit black and white. Import only. */
 	public static final int BITMAP = 8;
-	
+
 	/** 32-bit interleaved ARGB. Import only. */
 	public static final int ARGB = 9;
-	
+
 	/** 24-bit interleaved BGR. Import only. */
 	public static final int BGR = 10;
-	
+
 	/**	32-bit unsigned integer. Imported 32-bit integer images are
 		converted to floating-point. */
 	public static final int GRAY32_UNSIGNED = 11;
-	
+
 	/** 48-bit interleaved RGB. */
-	public static final int RGB48 = 12;	
+	public static final int RGB48 = 12;
 
 	/** 12-bit unsigned integer (0-4095). Import only. */
-	public static final int GRAY12_UNSIGNED = 13;	
+	public static final int GRAY12_UNSIGNED = 13;
 
 	/** 24-bit unsigned integer. Import only. */
-	public static final int GRAY24_UNSIGNED = 14;	
+	public static final int GRAY24_UNSIGNED = 14;
 
 	/** 32-bit interleaved BARG (MCID). Import only. */
-	public static final int BARG  = 15;	
+	public static final int BARG  = 15;
 
 	/** 64-bit floating-point. Import only.*/
-	public static final int GRAY64_FLOAT  = 16;	
+	public static final int GRAY64_FLOAT  = 16;
 
 	/** 48-bit planar RGB. Import only. */
-	public static final int RGB48_PLANAR = 17;	
+	public static final int RGB48_PLANAR = 17;
 
 	/** 32-bit interleaved ABGR. Import only. */
 	public static final int ABGR = 18;
 
 	/** 32-bit interleaved CMYK. Import only. */
 	public static final int CMYK = 19;
+
+	/** 10-bit unsigned integer (0-1023). Import only. */
+	public static final int GRAY10_UNSIGNED = 20;
 
 	// File formats
 	public static final int UNKNOWN = 0;
@@ -91,12 +94,12 @@ public class FileInfo implements Cloneable {
 	public static final int PACK_BITS = 5;
 	public static final int ZIP = 6;
 	public static final int ZIP_WITH_DIFFERENCING = 7;
-	
+
 	/* File format (TIFF, GIF_OR_JPG, BMP, etc.). Used by the File/Revert command */
 	public int fileFormat;
-	
+
 	/* File type (GRAY8, GRAY_16_UNSIGNED, RGB, etc.) */
-	public int fileType;	
+	public int fileType;
 	public String fileName;
 	public String directory;
 	public String url;
@@ -108,21 +111,21 @@ public class FileInfo implements Cloneable {
     public boolean whiteIsZero;
     public boolean intelByteOrder;
 	public int compression;
-    public int[] stripOffsets;  
+    public int[] stripOffsets;
     public int[] stripLengths;
     public int rowsPerStrip;
 	public int lutSize;
 	public byte[] reds;
 	public byte[] greens;
 	public byte[] blues;
-	public Object pixels;	
+	public Object pixels;
 	public String debugInfo;
 	public String[] sliceLabels;
 	public String info;
 	public InputStream inputStream;
 	public VirtualStack virtualStack;
 	public int sliceNumber; // used by FileInfoVirtualStack
-	
+
 	public double pixelWidth=1.0;
 	public double pixelHeight=1.0;
 	public double pixelDepth=1.0;
@@ -148,7 +151,7 @@ public class FileInfo implements Cloneable {
 	public String openNextDir, openNextName;
 	public String[] properties; // {key,value,key,value,...}
 	public boolean imageSaved;
-    
+
 	/** Creates a FileInfo object with all of its fields set to their default value. */
      public FileInfo() {
     	// assign default values
@@ -161,7 +164,7 @@ public class FileInfo implements Cloneable {
 		compression = COMPRESSION_NONE;
 		samplesPerPixel = 1;
     }
-    
+
      /** Returns the file path. */
 	public String getFilePath() {
 		String dir = directory;
@@ -175,7 +178,7 @@ public class FileInfo implements Cloneable {
     public final long getOffset() {
     	return longOffset>0L?longOffset:((long)offset)&0xffffffffL;
     }
-    
+
     /** Returns the gap between images as a long. */
     public final long getGap() {
     	return longGap>0L?longGap:((long)gapBetweenImages)&0xffffffffL;
@@ -185,7 +188,7 @@ public class FileInfo implements Cloneable {
 	public int getBytesPerPixel() {
 		switch (fileType) {
 			case GRAY8: case COLOR8: case BITMAP: return 1;
-			case GRAY16_SIGNED: case GRAY16_UNSIGNED: case GRAY12_UNSIGNED: return 2;
+			case GRAY16_SIGNED: case GRAY16_UNSIGNED: case GRAY12_UNSIGNED: case GRAY10_UNSIGNED: return 2;
 			case GRAY32_INT: case GRAY32_UNSIGNED: case GRAY32_FLOAT: case ARGB: case GRAY24_UNSIGNED: case BARG: case ABGR: case CMYK: return 4;
 			case RGB: case RGB_PLANAR: case BGR: return 3;
 			case RGB48: case RGB48_PLANAR: return 6;
@@ -213,7 +216,7 @@ public class FileInfo implements Cloneable {
 			+ ", ranges=" + (displayRanges!=null?""+displayRanges.length/2:"null")
 			+ ", samples=" + samplesPerPixel;
     }
-    
+
     /** Returns JavaScript code that can be used to recreate this FileInfo. */
     public String getCode() {
     	String code = "fi = new FileInfo();\n";
@@ -227,15 +230,15 @@ public class FileInfo implements Cloneable {
     	else if (fileType==RGB)
     		type = "RGB";
     	if (type!=null)
-    		code += "fi.fileType = FileInfo."+type+";\n"; 
+    		code += "fi.fileType = FileInfo."+type+";\n";
     	code += "fi.width = "+width+";\n";
     	code += "fi.height = "+height+";\n";
     	if (nImages>1)
-			code += "fi.nImages = "+nImages+";\n";  	
+			code += "fi.nImages = "+nImages+";\n";
     	if (getOffset()>0)
-			code += "fi.longOffset = "+getOffset()+";\n";  	
+			code += "fi.longOffset = "+getOffset()+";\n";
     	if (intelByteOrder)
-			code += "fi.intelByteOrder = true;\n";  	
+			code += "fi.intelByteOrder = true;\n";
     	return code;
     }
 
@@ -244,6 +247,8 @@ public class FileInfo implements Cloneable {
 			case GRAY8: return "byte";
 			case GRAY16_SIGNED: return "short";
 			case GRAY16_UNSIGNED: return "ushort";
+                        case GRAY10_UNSIGNED: return "ushort";
+                        case GRAY12_UNSIGNED: return "ushort";
 			case GRAY32_INT: return "int";
 			case GRAY32_UNSIGNED: return "uint";
 			case GRAY32_FLOAT: return "float";

--- a/ij/io/FileOpener.java
+++ b/ij/io/FileOpener.java
@@ -14,7 +14,7 @@ import ij.plugin.frame.*;
 /**
  * Opens or reverts an image specified by a FileInfo object. Images can
  * be loaded from either a file (directory+fileName) or a URL (url+fileName).
- * Here is an example:	
+ * Here is an example:
  * <pre>
  *   public class FileInfo_Test implements PlugIn {
  *     public void run(String arg) {
@@ -25,9 +25,9 @@ import ij.plugin.frame.*;
  *       fi.fileName = "blobs.tif";
  *       fi.directory = "/Users/wayne/Desktop/";
  *       new FileOpener(fi).open();
- *     }  
- *   }	
- * </pre> 
+ *     }
+ *   }
+ * </pre>
  */
 public class FileOpener {
 
@@ -45,7 +45,7 @@ public class FileOpener {
 		}
 		if (IJ.debugMode) IJ.log("FileInfo: "+fi);
 	}
-	
+
 	/** Opens the image and returns it has an ImagePlus object. */
 	public ImagePlus openImage() {
 		boolean wasRecording = Recorder.record;
@@ -59,7 +59,7 @@ public class FileOpener {
 	public void open() {
 		open(true);
 	}
-	
+
 	/** Obsolete, replaced by openImage() and open(). */
 	public ImagePlus open(boolean show) {
 
@@ -67,7 +67,7 @@ public class FileOpener {
 		Object pixels;
 		ProgressBar pb=null;
 	    ImageProcessor ip;
-		
+
 		ColorModel cm = createColorModel(fi);
 		if (fi.nImages>1)
 			return openStack(cm, show);
@@ -83,6 +83,7 @@ public class FileOpener {
 			case FileInfo.GRAY16_SIGNED:
 			case FileInfo.GRAY16_UNSIGNED:
 			case FileInfo.GRAY12_UNSIGNED:
+			case FileInfo.GRAY10_UNSIGNED:
 				pixels = readPixels(fi);
 				if (pixels==null) return null;
 	    		ip = new ShortProcessor(width, height, (short[])pixels, cm);
@@ -173,11 +174,11 @@ public class FileOpener {
 		if (show) imp.show();
 		return imp;
 	}
-	
+
 	public ImageProcessor openProcessor() {
 		Object pixels;
 		ProgressBar pb=null;
-		ImageProcessor ip = null;		
+		ImageProcessor ip = null;
 		ColorModel cm = createColorModel(fi);
 		switch (fi.fileType) {
 			case FileInfo.GRAY8:
@@ -190,6 +191,7 @@ public class FileOpener {
 			case FileInfo.GRAY16_SIGNED:
 			case FileInfo.GRAY16_UNSIGNED:
 			case FileInfo.GRAY12_UNSIGNED:
+			case FileInfo.GRAY10_UNSIGNED:
 				pixels = readPixels(fi);
 				if (pixels==null) return null;
 	    		ip = new ShortProcessor(width, height, (short[])pixels, cm);
@@ -302,11 +304,11 @@ public class FileOpener {
 		if (!silentMode) IJ.showProgress(1.0);
 		return imp;
 	}
-	
+
 	private void decodeAndSetRoi(ImagePlus imp, FileInfo fi) {
 		Roi roi = RoiDecoder.openFromByteArray(fi.roi);
 		imp.setRoi(roi);
-		if ((roi instanceof PointRoi) && ((PointRoi)roi).getNCounters()>1) 
+		if ((roi instanceof PointRoi) && ((PointRoi)roi).getNCounters()>1)
 			IJ.setTool("multi-point");
 	}
 
@@ -328,7 +330,7 @@ public class FileOpener {
 		imp.getProcessor().setMinAndMax(min, max);
 		imp.updateAndDraw();
 	}
-	
+
 	/** Restores the original version of the specified image. */
 	public void revertToSaved(ImagePlus imp) {
 		if (fi==null)
@@ -359,6 +361,7 @@ public class FileOpener {
 				case FileInfo.GRAY16_SIGNED:
 				case FileInfo.GRAY16_UNSIGNED:
 				case FileInfo.GRAY12_UNSIGNED:
+				case FileInfo.GRAY10_UNSIGNED:
 					ip = new ShortProcessor(width, height, (short[])pixels, cm);
 					imp.setProcessor(null, ip);
 					break;
@@ -383,7 +386,7 @@ public class FileOpener {
 			}
 		}
 	}
-	
+
 	void setCalibration(ImagePlus imp) {
 		if (fi.fileType==FileInfo.GRAY16_SIGNED) {
 			if (IJ.debugMode) IJ.log("16-bit signed");
@@ -409,7 +412,7 @@ public class FileOpener {
 			cal.setUnit(fi.unit);
 			calibrated = true;
 		}
-		
+
 		if (fi.valueUnit!=null) {
 			if (imp.getBitDepth()==32)
 				cal.setValueUnit(fi.valueUnit);
@@ -417,28 +420,28 @@ public class FileOpener {
 				int f = fi.calibrationFunction;
 				if ((f>=Calibration.STRAIGHT_LINE && f<=Calibration.EXP_RECOVERY && fi.coefficients!=null)
 				|| f==Calibration.UNCALIBRATED_OD) {
-					boolean zeroClip = props!=null && props.getProperty("zeroclip", "false").equals("true");	
+					boolean zeroClip = props!=null && props.getProperty("zeroclip", "false").equals("true");
 					cal.setFunction(f, fi.coefficients, fi.valueUnit, zeroClip);
 					calibrated = true;
 				}
 			}
 		}
-		
+
 		if (calibrated)
 			checkForCalibrationConflict(imp, cal);
-		
+
 		if (fi.frameInterval!=0.0)
 			cal.frameInterval = fi.frameInterval;
-		
+
 		if (props==null)
 			return;
-					
+
 		cal.xOrigin = getDouble(props,"xorigin");
 		cal.yOrigin = getDouble(props,"yorigin");
 		cal.zOrigin = getDouble(props,"zorigin");
 		cal.setInvertY(getBoolean(props, "inverty"));
-		cal.info = props.getProperty("info");		
-				
+		cal.info = props.getProperty("info");
+
 		cal.fps = getDouble(props,"fps");
 		cal.loop = getBoolean(props, "loop");
 		cal.frameInterval = getDouble(props,"finterval");
@@ -458,10 +461,10 @@ public class FileOpener {
 					ip.setMinAndMax(displayMin, displayMax);
 			}
 		}
-		
+
 		if (getBoolean(props, "8bitcolor"))
 			imp.setTypeToColor256(); // set type to COLOR_256
-		
+
 		int stackSize = imp.getStackSize();
 		if (stackSize>1) {
 			int channels = (int)getDouble(props,"channels");
@@ -479,7 +482,7 @@ public class FileOpener {
 		}
 	}
 
-		
+
 	void checkForCalibrationConflict(ImagePlus imp, Calibration cal) {
 		Calibration gcal = imp.getGlobalCalibration();
 		if  (gcal==null || !showConflictMessage || IJ.isMacro())
@@ -536,7 +539,7 @@ public class FileOpener {
 		}
 		return is;
 	}
-	
+
 	static boolean validateFileInfo(File f, FileInfo fi) {
 		long offset = fi.getOffset();
 		long length = 0;
@@ -629,7 +632,7 @@ public class FileOpener {
 		if (count>=2) {
 			fi.coefficients = new double[count];
 			for (int i=0; i<count; i++)
-				fi.coefficients[i] = c[i];			
+				fi.coefficients[i] = c[i];
 		}
 		fi.valueUnit = props.getProperty("vunit");
 		n = getNumber(props,"images");
@@ -653,27 +656,25 @@ public class FileOpener {
 			try {
 				return Double.valueOf(s);
 			} catch (NumberFormatException e) {}
-		}	
+		}
 		return null;
 	}
-	
+
 	private double getDouble(Properties props, String key) {
 		Double n = getNumber(props, key);
 		return n!=null?n.doubleValue():0.0;
 	}
-	
+
 	private boolean getBoolean(Properties props, String key) {
 		String s = props.getProperty(key);
 		return s!=null&&s.equals("true")?true:false;
 	}
-	
+
 	public static void setShowConflictMessage(boolean b) {
 		showConflictMessage = b;
 	}
-	
+
 	static void setSilentMode(boolean mode) {
 		silentMode = mode;
 	}
-
-
 }

--- a/ij/io/ImageReader.java
+++ b/ij/io/ImageReader.java
@@ -693,9 +693,15 @@ public class ImageReader {
 		return pixels;
 	}
 
+	/**
+	 * Reads in the contents of a 10-bit TIFF grayscale image file and converts to a 16-bit image.
+	 * 5 bytes are read-in at a time and produces 4 pixels.
+	 * @param in
+	 * @return the pixels of the 10-bit image
+	 * @throws IOException
+	 */
 	short[] read10bitImage(InputStream in) throws IOException {
-		int bytesPerLine = (int)(width*1.25);
-		//if ((width&1)==1) bytesPerLine++; // add 1 if odd
+		int bytesPerLine = (int)(width*1.25); // there are 1.25 bytes of data for each pixel (5 bytes per 4 pixels)
 		byte[] buffer = new byte[bytesPerLine*height];
 		short[] pixels = new short[nPixels];
 		DataInputStream dis = new DataInputStream(in);
@@ -705,36 +711,38 @@ public class ImageReader {
 			int index2 = y*width;
 			int count = 0;
 			while (count<width) {
-				final short B0 = (short) (buffer[index1] & 0xFF);
-				final short B1 = (short) (buffer[index1 + 1] & 0xFF);
-				final short B2 = (short) (buffer[index1 + 2] & 0xFF);
-				final short B3 = (short) (buffer[index1 + 3] & 0xFF);
-				final short B4 = (short) (buffer[index1 + 4] & 0xFF);
-				short b0, b1, b2, b3;
+				if (index1 + 4 < buffer.length) {
+					final short B0 = (short) (buffer[index1] & 0xFF);
+					final short B1 = (short) (buffer[index1 + 1] & 0xFF);
+					final short B2 = (short) (buffer[index1 + 2] & 0xFF);
+					final short B3 = (short) (buffer[index1 + 3] & 0xFF);
+					final short B4 = (short) (buffer[index1 + 4] & 0xFF);
+					short b0, b1, b2, b3;
 
-				// Set pixel 1
-				b0 = (short) (B0 << 2);
-				b1 = (short) (B1 >> 6);
-				pixels[index2 + count] = (short) (b0 | b1);
-				count++;
+					// Set pixel 1
+					b0 = (short) (B0 << 2);
+					b1 = (short) (B1 >> 6);
+					pixels[index2 + count] = (short) (b0 | b1);
+					count++;
 
-				// set pixel 2
-				b1 = (short) ((B1 & (0xFF >> 2)) << 4);
-				b2 = (short) (B2 >> 4);
-				pixels[index2 + count] = (short) (b1 | b2);
-				count++;
+					// set pixel 2
+					b1 = (short) ((B1 & (0xFF >> 2)) << 4);
+					b2 = (short) (B2 >> 4);
+					pixels[index2 + count] = (short) (b1 | b2);
+					count++;
 
-				// set pixel 3
-				b2 = (short) ((B2 & (0xFF >> 4)) << 6);
-				b3 = (short) (B3 >> 2);
-				pixels[index2 + count] = (short) (b2 | b3);
-				count++;
+					// set pixel 3
+					b2 = (short) ((B2 & (0xFF >> 4)) << 6);
+					b3 = (short) (B3 >> 2);
+					pixels[index2 + count] = (short) (b2 | b3);
+					count++;
 
-				// set pixel 4
-				b3 = (short) ((B3 & (0xFF >> 6)) << 8);
-				pixels[index2 + count] = (short) (b3 | B4);
-				count++;
-				index1 += 5;
+					// set pixel 4
+					b3 = (short) ((B3 & (0xFF >> 6)) << 8);
+					pixels[index2 + count] = (short) (b3 | B4);
+					count++;
+					index1 += 5;
+				}
 			}
 		}
 		return pixels;

--- a/ij/io/Opener.java
+++ b/ij/io/Opener.java
@@ -53,8 +53,8 @@ public class Opener {
 	}
 
 	/**
-	 * Displays a file open dialog box and then opens the tiff, dicom, 
-	 * fits, pgm, jpeg, bmp, gif, lut, roi, or text file selected by 
+	 * Displays a file open dialog box and then opens the tiff, dicom,
+	 * fits, pgm, jpeg, bmp, gif, lut, roi, or text file selected by
 	 * the user. Displays an error message if the selected file is not
 	 * in a supported format. This is the method that
 	 * ImageJ's File/Open command uses to open files.
@@ -76,8 +76,8 @@ public class Opener {
 	}
 
 	/**
-	 * Opens and displays the specified tiff, dicom, fits, pgm, jpeg, 
-	 * bmp, gif, lut, roi, or text file. Displays an error message if 
+	 * Opens and displays the specified tiff, dicom, fits, pgm, jpeg,
+	 * bmp, gif, lut, roi, or text file. Displays an error message if
 	 * the file is not in a supported format.
 	 * @see ij.IJ#open(String)
 	 * @see ij.IJ#openImage(String)
@@ -144,7 +144,7 @@ public class Opener {
 				case OJJ:  // ObjectJ project
 					IJ.runPlugIn("ObjectJ_", path);
 					break;
-				case TABLE: 
+				case TABLE:
 					openTable(path);
 					break;
 				case RAW:
@@ -154,7 +154,7 @@ public class Opener {
 					File f = new File(path);
 					String msg = (f.exists()) ?
 						"Format not supported or reader plugin not found:"
-						: "File not found:";					
+						: "File not found:";
 					if (path!=null) {
 						if (path.length()>64)
 							path = (new File(path)).getName();
@@ -170,10 +170,10 @@ public class Opener {
 			}
 		}
 	}
-		
-	/** Displays a JFileChooser and then opens the tiff, dicom, 
-		fits, pgm, jpeg, bmp, gif, lut, roi, or text files selected by 
-		the user. Displays error messages if one or more of the selected 
+
+	/** Displays a JFileChooser and then opens the tiff, dicom,
+		fits, pgm, jpeg, bmp, gif, lut, roi, or text files selected by
+		the user. Displays error messages if one or more of the selected
 		files is not in one of the supported formats. This is the method
 		that ImageJ's File/Open command uses to open files if
 		"Open/Save Using JFileChooser" is checked in EditOptions/Misc. */
@@ -219,7 +219,7 @@ public class Opener {
 		}
 		Java2.setLookAndFeel(saveLookAndFeel);
 	}
-	
+
 	/**
 	 * Opens, but does not display, the specified image file
 	 * and returns an ImagePlus object object if successful,
@@ -241,7 +241,7 @@ public class Opener {
 			img = openImage(getDir(path), getName(path));
 		return img;
 	}
-	
+
 	/**
 	 * Open the nth image of the specified tiff stack.
 	 * @see ij.IJ#openImage(String,int)
@@ -269,7 +269,7 @@ public class Opener {
 		int digits = rate<100.0?1:0;
 		return ""+IJ.d2s(time,2)+" seconds ("+IJ.d2s(mb/time,digits)+" MB/sec)";
 	}
-	
+
 	public static String makeFullPath(String path) {
 		if (path==null)
 			return path;
@@ -282,7 +282,7 @@ public class Opener {
 		}
 		return path;
 	}
-	
+
 	public static boolean isFullPath(String path) {
 		if (path==null)
 			return false;
@@ -303,7 +303,7 @@ public class Opener {
 		else
 			return false;
 	}
-	
+
 	/** Opens the specified file and adds it to the File/Open Recent menu.
 		Returns true if the file was opened successfully.  */
 	public boolean openAndAddToRecent(String path) {
@@ -316,7 +316,7 @@ public class Opener {
 	/**
 	 * Attempts to open the specified file as a tiff, bmp, dicom, fits,
 	 * pgm, gif or jpeg image. Returns an ImagePlus object if successful.
-	 * Modified by Gregory Jefferis to call HandleExtraFileTypes plugin if 
+	 * Modified by Gregory Jefferis to call HandleExtraFileTypes plugin if
 	 * the file type is unrecognised.
 	 * @see ij.IJ#openImage(String)
 	*/
@@ -354,7 +354,7 @@ public class Opener {
 			case GIF:
 				imp = (ImagePlus)IJ.runPlugIn("ij.plugin.GIF_Reader", path);
 				if (imp!=null&&imp.getWidth()!=0) return imp; else return null;
-			case PNG: 
+			case PNG:
 				imp = openUsingImageIO(directory+name);
 				if (imp!=null&&imp.getWidth()!=0) return imp; else return null;
 			case BMP:
@@ -388,14 +388,14 @@ public class Opener {
 				return null;
 		}
 	}
-	
+
 	public ImagePlus openTempImage(String directory, String name) {
 		ImagePlus imp = openImage(directory, name);
 		if (imp!=null)
 			imp.setTemporary();
 		return imp;
 	}
-	
+
 	// Call HandleExtraFileTypes plugin to see if it can handle unknown formats
 	// or files in TIFF format that the built in reader is unable to open.
 	private ImagePlus openUsingHandleExtraFileTypes(String path) {
@@ -412,7 +412,7 @@ public class Opener {
 			IJ.error("Opener", "Unsupported format or file not found:\n"+path);
 		return imp;
 	}
-	
+
 	String getPath() {
 		OpenDialog od = new OpenDialog("Open", "");
 		String dir = od.getDirectory();
@@ -432,9 +432,9 @@ public class Opener {
 	}
 
 	/**
-	 * Attempts to open the specified url as a tiff, zip compressed tiff, 
-	 * dicom, gif or jpeg. Tiff file names must end in ".tif", ZIP file names 
-	 * must end in ".zip" and dicom file names must end in ".dcm". Returns an 
+	 * Attempts to open the specified url as a tiff, zip compressed tiff,
+	 * dicom, gif or jpeg. Tiff file names must end in ".tif", ZIP file names
+	 * must end in ".zip" and dicom file names must end in ".dcm". Returns an
 	 * ImagePlus object if successful.
 	 * @see ij.IJ#openImage(String)
 	*/
@@ -489,9 +489,9 @@ public class Opener {
 			msg += "\n"+url;
 			IJ.error("Open URL", msg);
 			return null;
-		} 
+		}
 	}
-	
+
 	/** Can't open imagej.nih.gov URLs due to encryption so redirect to imagej.net mirror. */
 	public static String updateUrl(String url) {
 		if (url==null || !url.contains("nih.gov"))
@@ -505,7 +505,7 @@ public class Opener {
 		}
 		return url;
 	}
-	
+
 	private ImagePlus openCachedImage(String url) {
 		if (url==null || !url.contains("/images"))
 			return null;
@@ -544,7 +544,7 @@ public class Opener {
 		IJ.showStatus("");
 	}
 
-	
+
 	public ImagePlus openWithHandleExtraFileTypes(String path, int[] fileTypes) {
 		ImagePlus imp = null;
 		if (path.endsWith(".db")) {
@@ -597,7 +597,7 @@ public class Opener {
 		else
 			return openTiff(zis, name);
 	}
-	
+
 	ImagePlus openDicomStack(ZipInputStream zis, ZipEntry entry) throws IOException {
 		ImagePlus imp = null;
 		int count = 0;
@@ -686,7 +686,7 @@ public class Opener {
 			} catch (Exception e) {
 				IJ.error("Opener", e.getMessage()+"\n(Note: ImageJ cannot open CMYK JPEGs)\n \n"+dir+name);
 				return null; // error loading image
-			}				
+			}
 			if (imp.getType()==ImagePlus.COLOR_RGB)
 				convertGrayJpegTo8Bits(imp);
 			FileInfo fi = new FileInfo();
@@ -727,7 +727,7 @@ public class Opener {
 		}
 		return imp;
 	}
-	
+
 	public static ImagePlus openUsingImageIO(String path) {
 		ImagePlus imp = null;
 		BufferedImage img = null;
@@ -736,7 +736,7 @@ public class Opener {
 			img = ImageIO.read(f);
 		} catch (Exception e) {
 			IJ.error("Open Using ImageIO", ""+e);
-		} 
+		}
 		if (img==null)
 			return null;
 		if (IJ.debugMode) IJ.log("type="+img.getType()+", alpha="+img.getColorModel().hasAlpha()+", bands="+img.getSampleModel().getNumBands());
@@ -790,8 +790,8 @@ public class Opener {
 		//}
 		return sameSizeAndType;
 	}
-	
-	/** Attemps to open a tiff file as a stack. Returns 
+
+	/** Attemps to open a tiff file as a stack. Returns
 		an ImagePlus object if successful. */
 	public ImagePlus openTiffStack(FileInfo[] info) {
 		if (info.length>1 && !allSameSizeAndType(info))
@@ -806,11 +806,14 @@ public class Opener {
 			long skip = fi.getOffset();
 			int imageSize = fi.width*fi.height*fi.getBytesPerPixel();
 			if (info[0].fileType==FileInfo.GRAY12_UNSIGNED) {
-				imageSize = (int)(fi.width*fi.height*1.5);
-				if ((imageSize&1)==1) imageSize++; // add 1 if odd
-			} if (info[0].fileType==FileInfo.BITMAP) {
-				int scan=(int)Math.ceil(fi.width/8.0);
-				imageSize = scan*fi.height;
+			    imageSize = (int)(fi.width*fi.height*1.5);
+			    if ((imageSize&1)==1) imageSize++; // add 1 if odd
+			} else if (info[0].fileType==FileInfo.GRAY10_UNSIGNED) {
+                            imageSize = (int)(fi.width*fi.height*1.25);
+                            if ((imageSize&1)==1) imageSize++; // add 1 if odd
+			} else if (info[0].fileType==FileInfo.BITMAP) {
+			    int scan=(int)Math.ceil(fi.width/8.0);
+			    imageSize = scan*fi.height;
 			}
 			long loc = 0L;
 			int nChannels = 1;
@@ -838,7 +841,7 @@ public class Opener {
 							pixels = reader.readPixels(is, c==0?skip:0L);
 							channels[c] = pixels;
 						}
-					} else 
+					} else
 						pixels = reader.readPixels(is, skip);
 					if (pixels==null && channels==null) break;
 					loc += imageSize*nChannels+skip;
@@ -852,10 +855,10 @@ public class Opener {
 					}
 					if (fi.fileType==FileInfo.RGB48) {
 						Object[] pixels2 = (Object[])pixels;
-						stack.addSlice(null, pixels2[0]);					
-						stack.addSlice(null, pixels2[1]);					
+						stack.addSlice(null, pixels2[0]);
+						stack.addSlice(null, pixels2[1]);
 						stack.addSlice(null, pixels2[2]);
-						isRGB48 = true;					
+						isRGB48 = true;
 					} else if (nChannels>1) {
 						for (int c=0; c<nChannels; c++) {
 							if (channels[c]!=null)
@@ -904,7 +907,7 @@ public class Opener {
 			return imp;
 		}
 	}
-	
+
 	/** Attempts to open the specified file as a tiff.
 		Returns an ImagePlus object if successful. */
 	public ImagePlus openTiff(String directory, String name) {
@@ -922,7 +925,7 @@ public class Opener {
 			return null;
 		return openTiff2(info);
 	}
-	
+
 	/** Opens the nth image of the specified TIFF stack. */
 	public ImagePlus openTiff(String path, int n) {
 		TiffDecoder td = new TiffDecoder(getDir(path), getName(path));
@@ -950,8 +953,8 @@ public class Opener {
 				throw new IllegalArgumentException("N out of 1-"+info.length+" range");
 			fi.longOffset = info[n-1].getOffset();
 			fi.offset = 0;
-			fi.stripOffsets = info[n-1].stripOffsets; 
-			fi.stripLengths = info[n-1].stripLengths; 
+			fi.stripOffsets = info[n-1].stripOffsets;
+			fi.stripLengths = info[n-1].stripLengths;
 		}
 		FileOpener fo = new FileOpener(fi);
 		return fo.openImage();
@@ -999,7 +1002,7 @@ public class Opener {
 	}
 
 	/** Opens a single TIFF or DICOM contained in a ZIP archive,
-		or a ZIPed collection of ".roi" files created by the ROI manager. */	
+		or a ZIPed collection of ".roi" files created by the ROI manager. */
 	public ImagePlus openZip(String path) {
 		ImagePlus imp = null;
 		try {
@@ -1050,7 +1053,7 @@ public class Opener {
 		}
 		return imp;
 	}
-	
+
 	/** Deserialize a byte array that was serialized using the FileSaver.serialize(). */
 	public ImagePlus deserialize(byte[] bytes) {
 		ByteArrayInputStream stream = new ByteArrayInputStream(bytes);
@@ -1071,7 +1074,7 @@ public class Opener {
 		imp = makeComposite(imp, info[0]);
 		return imp;
    }
-   
+
 	private ImagePlus makeComposite(ImagePlus imp, FileInfo fi) {
 		int c = imp.getNChannels();
 		boolean composite = c>1 && fi.description!=null && fi.description.indexOf("mode=")!=-1;
@@ -1088,7 +1091,7 @@ public class Opener {
 		return imp;
 	}
 
-		
+
 	public String getName(String path) {
 		int i = path.lastIndexOf('/');
 		if (i==-1)
@@ -1098,7 +1101,7 @@ public class Opener {
 		else
 			return path;
 	}
-	
+
 	public String getDir(String path) {
 		int i = path.lastIndexOf('/');
 		if (i==-1)
@@ -1137,7 +1140,7 @@ public class Opener {
 		else
 			return imp;
 	}
-	
+
 	private ImagePlus openFFT(ImagePlus imp) {
 		ImageProcessor ip = imp.getProcessor();
 		FHT fht = new FHT(ip, true);
@@ -1152,7 +1155,7 @@ public class Opener {
 		imp2.setCalibration(imp.getCalibration());
 		return imp2;
 	}
-	
+
 	/** Attempts to open the specified ROI, returning null if unsuccessful. */
 	public Roi openRoi(String path) {
 		Roi roi = null;
@@ -1164,7 +1167,7 @@ public class Opener {
 		}
 		return roi;
 	}
-	
+
 	/** Opens an image file using the Bio-Formats plugin. */
 	public static ImagePlus openUsingBioFormats(String path) {
 		String className = "loci.plugins.BF";
@@ -1187,7 +1190,7 @@ public class Opener {
 		} catch(Exception e) {}
 		return null;
 	}
-	
+
 	/*
 	public static boolean isRGBStack(ImagePlus imp) {
 		if (imp==null)
@@ -1202,7 +1205,7 @@ public class Opener {
 				rgb = false;
 				break;
 			}
-			byte[] bytes = lut.getBytes();				
+			byte[] bytes = lut.getBytes();
 			if (bytes==null) {
 				rgb = false;
 				break;
@@ -1238,7 +1241,7 @@ public class Opener {
 			IJ.error("Open Results", e.getMessage());
 		}
 	}
-	
+
 	/** Opens a tab or comma delimited text file. */
 	public static void openTable(String path) {
 		String name = "";
@@ -1270,7 +1273,7 @@ public class Opener {
 		else
 			return Opener.types[(new Opener()).getFileType(path)];
 	}
-	
+
 	/**
 	Attempts to determine the image file type by looking for
 	'magic numbers' and the file name extension.
@@ -1289,10 +1292,10 @@ public class Opener {
 		} catch (IOException e) {
 			return UNKNOWN;
 		}
-		
+
 		int b0=buf[0]&255, b1=buf[1]&255, b2=buf[2]&255, b3=buf[3]&255;
 		//IJ.log("getFileType: "+ name+" "+b0+" "+b1+" "+b2+" "+b3);
-		
+
 		 // Combined TIFF and DICOM created by GE Senographe scanners
 		if (buf[128]==68 && buf[129]==73 && buf[130]==67 && buf[131]==77
 		&& ((b0==73 && b1==73)||(b0==77 && b1==77)))
@@ -1324,7 +1327,7 @@ public class Opener {
 		}
 
 		// ACR/NEMA with first tag = 00002,00xx or 00008,00xx
-		if ((b0==8||b0==2) && b1==0 && b3==0 && !name.endsWith(".spe") && !name.equals("fid"))	
+		if ((b0==8||b0==2) && b1==0 && b3==0 && !name.endsWith(".spe") && !name.equals("fid"))
 				return DICOM;
 
 		// PGM ("P1", "P4", "P2", "P5", "P3" or "P6")
@@ -1334,11 +1337,11 @@ public class Opener {
 		// Lookup table
 		if (name.endsWith(".lut"))
 			return LUT;
-		
+
 		// PNG
 		if (b0==137 && b1==80 && b2==78 && b3==71)
 			return PNG;
-				
+
 		// ZIP containing a TIFF
 		if (name.endsWith(".zip"))
 			return ZIP;
@@ -1346,7 +1349,7 @@ public class Opener {
 		// FITS ("SIMP")
 		if ((b0==83 && b1==73 && b2==77 && b3==80) || name.endsWith(".fts.gz") || name.endsWith(".fits.gz"))
 			return FITS;
-			
+
 		// Java source file, text file or macro
 		if (name.endsWith(".java") || name.endsWith(".txt") || name.endsWith(".ijm") || name.endsWith(".js")
 			|| name.endsWith(".bsh") || name.endsWith(".py") || name.endsWith(".html"))
@@ -1355,13 +1358,13 @@ public class Opener {
 		// ImageJ, NIH Image, Scion Image for Windows ROI
 		if (b0==73 && b1==111) // "Iout"
 			return ROI;
-			
+
 		// ObjectJ project
 		if ((b0=='o' && b1=='j' && b2=='j' && b3==0) || name.endsWith(".ojj") )
 			return OJJ;
 
 		// Results table (tab-delimited or comma-separated tabular text)
-		if (name.endsWith(".xls") || name.endsWith(".csv") || name.endsWith(".tsv")) 
+		if (name.endsWith(".xls") || name.endsWith(".csv") || name.endsWith(".tsv"))
 			return TABLE;
 
 		// AVI
@@ -1383,7 +1386,7 @@ public class Opener {
 		// BMP ("BM")
 		if ((b0==66 && b1==77)||name.endsWith(".dib"))
 			return BMP;
-				
+
 		// RAW
 		if (name.endsWith(".raw") && !Prefs.skipRawDialog)
 			return RAW;
@@ -1417,7 +1420,7 @@ public class Opener {
 			}
 		}
 	}
-	
+
 	void openRGB48(ImagePlus imp) {
 			isRGB48 = false;
 			int stackSize = imp.getStackSize();
@@ -1425,7 +1428,7 @@ public class Opener {
 			imp = new CompositeImage(imp, IJ.COMPOSITE);
 			imp.show();
 	}
-	
+
 	/** The "Opening: path" status message is not displayed in silent mode. */
 	public void setSilentMode(boolean mode) {
 		silentMode = mode;
@@ -1441,5 +1444,5 @@ public class Opener {
 	public static boolean getOpenUsingPlugins() {
 		return openUsingPlugins;
 	}
-		
+
 }

--- a/ij/io/TiffDecoder.java
+++ b/ij/io/TiffDecoder.java
@@ -43,7 +43,7 @@ public class TiffDecoder {
 	public static final int NIH_IMAGE_HDR = 43314;
 	public static final int META_DATA_BYTE_COUNTS = 50838; // private tag registered with Adobe
 	public static final int META_DATA = 50839; // private tag registered with Adobe
-	
+
 	//constants
 	static final int UNSIGNED = 1;
 	static final int SIGNED = 2;
@@ -63,7 +63,7 @@ public class TiffDecoder {
 	static final int ROI = 0x726f6920;     // "roi " (ROI)
 	static final int OVERLAY = 0x6f766572; // "over" (overlay)
 	static final int PROPERTIES = 0x70726f70; // "prop" (properties)
-	
+
 	private String directory;
 	private String name;
 	private String url;
@@ -75,7 +75,7 @@ public class TiffDecoder {
 	private int[] metaDataCounts;
 	private String tiffMetadata;
 	private int photoInterp;
-		
+
 	public TiffDecoder(String directory, String name) {
 		if (directory==null)
 			directory = "";
@@ -101,7 +101,7 @@ public class TiffDecoder {
 		else
 			return ((b1 << 24) + (b2 << 16) + (b3 << 8) + b4);
 	}
-	
+
 	final long getUnsignedInt() throws IOException {
 		return (long)getInt()&0xffffffffL;
 	}
@@ -144,7 +144,7 @@ public class TiffDecoder {
 		long offset = ((long)getInt())&0xffffffffL;
 		return offset;
 	}
-		
+
 	int getValue(int fieldType, int count) throws IOException {
 		int value = 0;
 		int unused;
@@ -154,8 +154,8 @@ public class TiffDecoder {
 		} else
 			value = getInt();
 		return value;
-	}	
-	
+	}
+
 	void getColorMap(long offset, FileInfo fi) throws IOException {
 		byte[] colorTable16 = new byte[768*2];
 		long saveLoc = in.getLongFilePointer();
@@ -181,7 +181,7 @@ public class TiffDecoder {
 		if (sum!=0 && fi.fileType==FileInfo.GRAY8)
 			fi.fileType = FileInfo.COLOR8;
 	}
-	
+
 	byte[] getString(int count, long offset) throws IOException {
 		count--; // skip null byte at end of string
 		if (count<=3)
@@ -228,16 +228,16 @@ public class TiffDecoder {
 
 	void decodeNIHImageHeader(int offset, FileInfo fi) throws IOException {
 		long saveLoc = in.getLongFilePointer();
-		
+
 		in.seek(offset+12);
 		int version = in.readShort();
-		
+
 		in.seek(offset+160);
 		double scale = in.readDouble();
 		if (version>106 && scale!=0.0) {
 			fi.pixelWidth = 1.0/scale;
 			fi.pixelHeight = fi.pixelWidth;
-		} 
+		}
 
 		// spatial calibration
 		in.seek(offset+172);
@@ -288,7 +288,7 @@ public class TiffDecoder {
 			} else
 				fi.valueUnit = " ";
 		}
-			
+
 		in.seek(offset+260);
 		int nImages = in.readShort();
 		if (nImages>=2 && (fi.fileType==FileInfo.GRAY8||fi.fileType==FileInfo.COLOR8)) {
@@ -297,15 +297,15 @@ public class TiffDecoder {
 			int skip = in.readShort();		//CurrentSlice
 			fi.frameInterval = in.readFloat();
 		}
-			
+
 		in.seek(offset+272);
 		float aspectRatio = in.readFloat();
 		if (version>140 && aspectRatio!=0.0)
 			fi.pixelHeight = fi.pixelWidth/aspectRatio;
-		
+
 		in.seek(saveLoc);
 	}
-	
+
 	void dumpTag(int tag, int count, int value, FileInfo fi) {
 		long lvalue = ((long)value)&0xffffffffL;
 		String name = getName(tag);
@@ -336,14 +336,14 @@ public class TiffDecoder {
 			case ARTIST: name="Artist"; break;
 			case HOST_COMPUTER: name="HostComputer"; break;
 			case PLANAR_CONFIGURATION: name="PlanarConfiguration"; break;
-			case COMPRESSION: name="Compression"; break; 
-			case PREDICTOR: name="Predictor"; break; 
-			case COLOR_MAP: name="ColorMap"; break; 
-			case SAMPLE_FORMAT: name="SampleFormat"; break; 
-			case JPEG_TABLES: name="JPEGTables"; break; 
-			case NIH_IMAGE_HDR: name="NIHImageHeader"; break; 
-			case META_DATA_BYTE_COUNTS: name="MetaDataByteCounts"; break; 
-			case META_DATA: name="MetaData"; break; 
+			case COMPRESSION: name="Compression"; break;
+			case PREDICTOR: name="Predictor"; break;
+			case COLOR_MAP: name="ColorMap"; break;
+			case SAMPLE_FORMAT: name="SampleFormat"; break;
+			case JPEG_TABLES: name="JPEGTables"; break;
+			case NIH_IMAGE_HDR: name="NIHImageHeader"; break;
+			case META_DATA_BYTE_COUNTS: name="MetaDataByteCounts"; break;
+			case META_DATA: name="MetaData"; break;
 			default: name="???"; break;
 		}
 		return name;
@@ -360,7 +360,7 @@ public class TiffDecoder {
 		else
 			return 0.0;
 	}
-	
+
 	FileInfo OpenIFD() throws IOException {
 	// Get Image File Directory data
 		int tag, fieldType, count, value;
@@ -380,11 +380,11 @@ public class TiffDecoder {
 			long lvalue = ((long)value)&0xffffffffL;
 			if (debugMode && ifdCount<10) dumpTag(tag, count, value, fi);
 			switch (tag) {
-				case IMAGE_WIDTH: 
+				case IMAGE_WIDTH:
 					fi.width = value;
 					fi.intelByteOrder = littleEndian;
 					break;
-				case IMAGE_LENGTH: 
+				case IMAGE_LENGTH:
 					fi.height = value;
 					break;
  				case STRIP_OFFSETS:
@@ -432,6 +432,8 @@ public class TiffDecoder {
 								fi.fileType = FileInfo.GRAY32_INT;
 							else if (value==12)
 								fi.fileType = FileInfo.GRAY12_UNSIGNED;
+							else if (value==10)
+								fi.fileType = FileInfo.GRAY10_UNSIGNED;
 							else if (value==1)
 								fi.fileType = FileInfo.BITMAP;
 							else
@@ -467,12 +469,12 @@ public class TiffDecoder {
 					fi.rowsPerStrip = value;
 					break;
 				case X_RESOLUTION:
-					double xScale = getRational(lvalue); 
-					if (xScale!=0.0) fi.pixelWidth = 1.0/xScale; 
+					double xScale = getRational(lvalue);
+					if (xScale!=0.0) fi.pixelWidth = 1.0/xScale;
 					break;
 				case Y_RESOLUTION:
-					double yScale = getRational(lvalue); 
-					if (yScale!=0.0) fi.pixelHeight = 1.0/yScale; 
+					double yScale = getRational(lvalue);
+					if (yScale!=0.0) fi.pixelHeight = 1.0/yScale;
 					break;
 				case RESOLUTION_UNIT:
 					if (value==1&&fi.unit==null)
@@ -501,6 +503,8 @@ public class TiffDecoder {
 						fi.compression = FileInfo.LZW;
 						if (fi.fileType==FileInfo.GRAY12_UNSIGNED)
 							error("ImageJ cannot open 12-bit LZW-compressed TIFFs");
+						if (fi.fileType==FileInfo.GRAY10_UNSIGNED)
+							error("ImageJ cannot open 10-bit LZW-compressed TIFFs");
 					} else if (value==32773)  // PackBits compression
 						fi.compression = FileInfo.PACK_BITS;
 					else if (value==32946 || value==8) //8=Adobe deflate
@@ -529,7 +533,7 @@ public class TiffDecoder {
 					} else if (value==3)
 						IJ.log("TiffDecoder: unsupported predictor value of 3");
 					break;
-				case COLOR_MAP: 
+				case COLOR_MAP:
 					if (count==768)
 						getColorMap(lvalue, fi);
 					break;
@@ -550,7 +554,7 @@ public class TiffDecoder {
 					if (fi.compression==FileInfo.JPEG)
 						error("Cannot open JPEG-compressed TIFFs with separate tables");
 					break;
-				case IMAGE_DESCRIPTION: 
+				case IMAGE_DESCRIPTION:
 					if (ifdCount==1) {
 						byte[] s = getString(count, lvalue);
 						if (s!=null) saveImageDescription(s,fi);
@@ -567,14 +571,14 @@ public class TiffDecoder {
 							fi.nImages=9999;
 					}
 					break;
-				case IPLAB: 
+				case IPLAB:
 					fi.nImages=value;
 					break;
-				case NIH_IMAGE_HDR: 
+				case NIH_IMAGE_HDR:
 					if (count==256)
 						decodeNIHImageHeader(value, fi);
 					break;
- 				case META_DATA_BYTE_COUNTS: 
+ 				case META_DATA_BYTE_COUNTS:
 					long saveLoc = in.getLongFilePointer();
 					in.seek(lvalue);
 					metaDataCounts = new int[count];
@@ -582,7 +586,7 @@ public class TiffDecoder {
 						metaDataCounts[c] = getInt();
 					in.seek(saveLoc);
 					break;
- 				case META_DATA: 
+ 				case META_DATA:
  					getMetaData(value, fi);
  					break;
 				default:
@@ -617,7 +621,7 @@ public class TiffDecoder {
 		}
 		int nTypes = (hdrSize-4)/8;
 		int[] types = new int[nTypes];
-		int[] counts = new int[nTypes];		
+		int[] counts = new int[nTypes];
 		if (debugMode) {
 			dInfo += "Metadata:\n";
 			dInfo += "   Entries: "+(metaDataCounts.length-1)+"\n";
@@ -670,13 +674,13 @@ public class TiffDecoder {
 			else if (types[i]==PROPERTIES)
 				getProperties(start, start+counts[i]-1, fi);
 			else if (types[i]<0xffffff) {
-				for (int j=start; j<start+counts[i]; j++) { 
-					int len = metaDataCounts[j]; 
-					fi.metaData[eMDindex] = new byte[len]; 
-					in.readFully(fi.metaData[eMDindex], len); 
-					fi.metaDataTypes[eMDindex] = types[i]; 
-					eMDindex++; 
-				} 
+				for (int j=start; j<start+counts[i]; j++) {
+					int len = metaDataCounts[j];
+					fi.metaData[eMDindex] = new byte[len];
+					in.readFully(fi.metaData[eMDindex], len);
+					fi.metaDataTypes[eMDindex] = types[i];
+					eMDindex++;
+				}
 			} else
 				skipUnknownType(start, start+counts[i]-1);
 			start += counts[i];
@@ -746,8 +750,8 @@ public class TiffDecoder {
 
 	void getRoi(int first, FileInfo fi) throws IOException {
 		int len = metaDataCounts[first];
-		fi.roi = new byte[len]; 
-		in.readFully(fi.roi, len); 
+		fi.roi = new byte[len];
+		in.readFully(fi.roi, len);
 	}
 
 	void getPlot(int first, FileInfo fi) throws IOException {
@@ -793,7 +797,7 @@ public class TiffDecoder {
 		if (in!=null) in.close();
 		throw new IOException(message);
 	}
-	
+
 	void skipUnknownType(int first, int last) throws IOException {
 	    byte[] buffer = new byte[metaDataCounts[first]];
 		for (int i=first; i<=last; i++) {
@@ -807,7 +811,7 @@ public class TiffDecoder {
 	public void enableDebugging() {
 		debugMode = true;
 	}
-		
+
 	public FileInfo[] getTiffInfo() throws IOException {
 		long ifdOffset;
 		ArrayList list = new ArrayList();
@@ -857,7 +861,7 @@ public class TiffDecoder {
 			return info;
 		}
 	}
-	
+
 	String getGapInfo(FileInfo[] fi) {
 		if (fi.length<2) return "0";
 		long minGap = Long.MAX_VALUE;
@@ -872,7 +876,7 @@ public class TiffDecoder {
 		maxGap -= imageSize;
 		if (minGap==maxGap)
 			return ""+minGap;
-		else 
+		else
 			return "varies ("+minGap+" to "+maxGap+")";
 	}
 

--- a/ij/io/TiffEncoder.java
+++ b/ij/io/TiffEncoder.java
@@ -7,7 +7,7 @@ public class TiffEncoder {
 	static final int MAP_SIZE = 768; // in 16-bit words
 	static final int BPS_DATA_SIZE = 6;
 	static final int SCALE_DATA_SIZE = 16;
-		
+
 	private FileInfo fi;
 	private int bitsPerSample;
 	private int photoInterp;
@@ -28,7 +28,7 @@ public class TiffEncoder {
 	private byte buffer[] = new byte[8];
 	private int colorMapSize = 0;
 
-		
+
 	public TiffEncoder (FileInfo fi) {
 		this.fi = fi;
 		fi.intelByteOrder = littleEndian;
@@ -103,7 +103,7 @@ public class TiffEncoder {
 		fi.offset = (int)imageOffset;
 		//ij.IJ.log(imageOffset+", "+ifdSize+", "+bpsSize+", "+descriptionSize+", "+scaleSize+", "+colorMapSize+", "+nMetaDataEntries*4+", "+metaDataSize);
 	}
-	
+
 	/** Saves the image as a TIFF file. The OutputStream is not closed.
 		The fi.pixels field must contain the image data. If fi.nImages>1
 		then fi.pixels must be a 2D array. The fi.offset field is ignored. */
@@ -145,7 +145,7 @@ public class TiffEncoder {
 		} else if (bigTiff)
 				ij.IJ.log("Stack is larger than 4GB. Most TIFF readers will only open the first image. Use this information to open as raw:\n"+fi);
 	}
-	
+
 	public void write(DataOutputStream out) throws IOException {
 		write((OutputStream)out);
 	}
@@ -239,7 +239,7 @@ public class TiffEncoder {
 		nMetaDataTypes = nTypes;
 		return size;
 	}
-	
+
 	/** Writes the 8-byte image file header. */
 	void writeHeader(OutputStream out) throws IOException {
 		byte[] hdr = new byte[8];
@@ -264,7 +264,7 @@ public class TiffEncoder {
 		}
 		out.write(hdr);
 	}
-	
+
 	/** Writes one 12-byte IFD entry. */
 	void writeEntry(OutputStream out, int tag, int fieldType, int count, int value) throws IOException {
 		writeShort(out, tag);
@@ -276,9 +276,9 @@ public class TiffEncoder {
 		} else
 			writeInt(out, value); // may be an offset
 	}
-	
+
 	/** Writes one IFD (Image File Directory). */
-	void writeIFD(OutputStream out, int imageOffset, int nextIFD) throws IOException {	
+	void writeIFD(OutputStream out, int imageOffset, int nextIFD) throws IOException {
 		int tagDataOffset = HDR_SIZE + ifdSize;
 		writeShort(out, nEntries);
 		writeEntry(out, TiffDecoder.NEW_SUBFILE_TYPE, 4, 1, 0);
@@ -325,7 +325,7 @@ public class TiffEncoder {
 		}
 		writeInt(out, nextIFD);
 	}
-	
+
 	/** Writes the 6 bytes of data required by RGB BitsPerSample tag. */
 	void writeBitsPerPixel(OutputStream out) throws IOException {
 		int bitsPerPixel = fi.fileType==FileInfo.RGB48?16:8;
@@ -364,14 +364,14 @@ public class TiffEncoder {
 		}
 		out.write(colorTable16);
 	}
-	
-	/** Writes image metadata ("info" property, 
+
+	/** Writes image metadata ("info" property,
 		stack slice labels, channel display ranges, luts, ROIs,
 		overlays, properties and extra metadata). */
 	void writeMetaData(OutputStream out) throws IOException {
-	
+
 		// write byte counts (META_DATA_BYTE_COUNTS tag)
-		writeInt(out, 4+nMetaDataTypes*8); // header size	
+		writeInt(out, 4+nMetaDataTypes*8); // header size
 		if (fi.info!=null && fi.info.length()>0)
 			writeInt(out, fi.info.length()*2);
 		for (int i=0; i<nSliceLabels; i++) {
@@ -399,8 +399,8 @@ public class TiffEncoder {
 				writeInt(out, fi.properties[i].length()*2);
 		}
 		for (int i=0; i<extraMetaDataEntries; i++)
-			writeInt(out, fi.metaData[i].length);	
-		
+			writeInt(out, fi.metaData[i].length);
+
 		// write header (META_DATA tag header)
 		writeInt(out, TiffDecoder.MAGIC_NUMBER); // "IJIJ"
 		if (fi.info!=null) {
@@ -439,7 +439,7 @@ public class TiffEncoder {
 			writeInt(out, fi.metaDataTypes[i]);
 			writeInt(out, 1); // count
 		}
-		
+
 		// write data (META_DATA tag body)
 		if (fi.info!=null)
 			writeChars(out, fi.info);
@@ -468,7 +468,7 @@ public class TiffEncoder {
 				writeChars(out, fi.properties[i]);
 		}
 		for (int i=0; i<extraMetaDataEntries; i++)
-			out.write(fi.metaData[i]); 					
+			out.write(fi.metaData[i]);
 	}
 
 	/** Creates an optional image description string for saving calibration data.
@@ -483,7 +483,7 @@ public class TiffEncoder {
 		} else
 			description = null;
 	}
-		
+
 	final void writeShort(OutputStream out, int v) throws IOException {
 		if (littleEndian) {
        		out.write(v&255);
@@ -535,22 +535,21 @@ public class TiffEncoder {
     final void writeDouble(OutputStream out, double v) throws IOException {
 		writeLong(out, Double.doubleToLongBits(v));
     }
-    
+
 	final void writeChars(OutputStream out, String s) throws IOException {
         int len = s.length();
         if (littleEndian) {
 			for (int i = 0 ; i < len ; i++) {
 				int v = s.charAt(i);
-				out.write(v&255); 
-				out.write((v>>>8)&255); 
+				out.write(v&255);
+				out.write((v>>>8)&255);
 			}
         } else {
 			for (int i = 0 ; i < len ; i++) {
 				int v = s.charAt(i);
-				out.write((v>>>8)&255); 
-				out.write(v&255); 
+				out.write((v>>>8)&255);
+				out.write(v&255);
 			}
         }
     }
-    
 }

--- a/ij/plugin/FileInfoVirtualStack.java
+++ b/ij/plugin/FileInfoVirtualStack.java
@@ -7,12 +7,12 @@ import java.awt.*;
 import java.io.*;
 import java.util.Properties;
 
-/** This plugin opens a multi-page TIFF file, or a set of raw images, as a 
+/** This plugin opens a multi-page TIFF file, or a set of raw images, as a
 	virtual stack. It implements the File/Import/TIFF Virtual Stack command. */
 public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 	private FileInfo[] info;
 	private int nImages;
-	
+
 	/* Default constructor. */
 	public FileInfoVirtualStack() {}
 
@@ -25,7 +25,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 			imp.show();
 	}
 
-	/* Constructs a FileInfoVirtualStack from a FileInfo 
+	/* Constructs a FileInfoVirtualStack from a FileInfo
 		object and displays it if 'show' is true. */
 	public FileInfoVirtualStack(FileInfo fi, boolean show) {
 		info = new FileInfo[1];
@@ -34,7 +34,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		if (imp!=null && show)
 			imp.show();
 	}
-	
+
 	/* Constructs a FileInfoVirtualStack from an array of FileInfo objects. */
 	public FileInfoVirtualStack(FileInfo[] fi) {
 		info = fi;
@@ -69,7 +69,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		if (imp!=null)
 			imp.show();
 	}
-	
+
 	private void init(String dir, String name) {
 		if (name.endsWith(".zip")) {
 			IJ.error("Virtual Stack", "ZIP compressed stacks not supported");
@@ -93,7 +93,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		if (IJ.debugMode)
 			IJ.log(info[0].debugInfo);
 	}
-		
+
 	private ImagePlus open() {
 		FileInfo fi = info[0];
 		int n = fi.nImages;
@@ -101,6 +101,8 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 			long bytesPerImage = fi.width*fi.height*fi.getBytesPerPixel();
 			if (fi.fileType==FileInfo.GRAY12_UNSIGNED)
 				bytesPerImage = (int)(1.5*fi.width)*fi.height;
+			if (fi.fileType==FileInfo.GRAY10_UNSIGNED)
+				bytesPerImage = (int)(1.25*fi.width)*fi.height;
 			n = validateNImages(fi, bytesPerImage);
 			info = new FileInfo[n];
 			for (int i=0; i<n; i++) {
@@ -145,7 +147,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		}
 		return imp2;
 	}
-	
+
 	private int validateNImages(FileInfo fi, long bytesPerImage) {
 		File f = new File(fi.getFilePath());
 		if (!f.exists())
@@ -170,7 +172,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 			try {
 				return Double.valueOf(s);
 			} catch (NumberFormatException e) {}
-		}	
+		}
 		return null;
 	}
 
@@ -189,7 +191,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		info[nImages-1] = null;
 		nImages--;
 	}
-	
+
 	/** Returns an ImageProcessor for the specified image,
 		where {@literal 1<=n<=nImages}. Returns null if the stack is empty.
 	*/
@@ -231,7 +233,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 			}
 		}
 	 }
- 
+
 	/** Returns the number of slices in this stack. */
 	public int size() {
 		return getSize();
@@ -254,11 +256,11 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 	public int getWidth() {
 		return info[0].width;
 	}
-	
+
 	public int getHeight() {
 		return info[0].height;
 	}
-	
+
 	/** Adds an image to this stack. */
 	public synchronized  void addImage(FileInfo fileInfo) {
 		nImages++;
@@ -271,7 +273,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		}
 		info[nImages-1] = fileInfo;
 	}
-	
+
 	@Override
 	public String getDirectory() {
 		if (info!=null && info.length>0)
@@ -279,7 +281,7 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		else
 			return null;
 	}
-		
+
 	@Override
 	public String getFileName(int n) {
 		int index = n - 1;
@@ -288,6 +290,4 @@ public class FileInfoVirtualStack extends VirtualStack implements PlugIn {
 		else
 			return null;
 	}
-
-		
 }


### PR DESCRIPTION
Hello - I was asked by Accelerate Diagnostics Inc. to add support to ImageJ for 10-bit TIFF images produced by their equipment.  This PR contains this functionality.  The meat of the code is a new "read10bitImage()" function inside of ImageReader.java, along with a new file info constant, GRAY10_UNSIGNED.  I tried to keep the code consistent with how the other bit-length reader functions are implemented.   This code was tested against several 10-bit TIFF files provided by Accelerate and worked well.  To accomplish this, the read10bitImage() function reads in 5 bytes of data at a time, and produces 4 pixels of information.  The result is that each new pixel contains no data loss, so the fidelity of the image is not reduced with this conversion.  Each new 16-bit pixel contains the original 10-bits of information; the remaining unused 6-bits are set to 0 (left-padded).

Accelerate Diagnostics Inc has been a happy user of ImageJ for years, and are excited that this small contribution may make its way into the core product, to benefit other users.

Thank you for your consideration of this PR.
-Paul