### PR TITLE
Improved the ScreenGrabber class. Minor fixes to avoid some warnings.

### DIFF
--- a/ij/Menus.java
+++ b/ij/Menus.java
@@ -936,6 +936,7 @@ public class Menus {
         		if (entry.getName().endsWith("plugins.config"))
 					return jarFile.getInputStream(entry);
 			}
+			jarFile.close();
 		}
     	catch (Throwable e) {
     		IJ.log(jar+": "+e);
@@ -971,6 +972,7 @@ public class Menus {
 					sb.append(plugins + ", \""+name+"\", "+className+"\n");
 				}
 			}
+			jarFile.close();
 		}
     	catch (Throwable e) {
     		IJ.log(jar+": "+e);

--- a/ij/gui/Plot.java
+++ b/ij/gui/Plot.java
@@ -613,12 +613,12 @@ public class Plot implements Cloneable {
 	/** Sets the length of the major tick in pixels.
 	 *	Call update() thereafter to make the change visible (if the image is shown already). */
 	public void setTickLength(int tickLength) {
-			tickLength = tickLength;
+			this.tickLength = tickLength;
 	}
 
 	/** Sets the length of the minor tick in pixels. */
 	public void setMinorTickLength(int minorTickLength) {
-			minorTickLength = minorTickLength;
+			this.minorTickLength = minorTickLength;
 	}
 
 	/** Sets the flags that control the axes format.

--- a/ij/gui/PlotVirtualStack.java
+++ b/ij/gui/PlotVirtualStack.java
@@ -11,7 +11,6 @@ public class PlotVirtualStack extends VirtualStack {
 	
 	public PlotVirtualStack(int width, int height) {
 		super(width, height);
-		this.bitDepth = bitDepth;
 	}
 	
 	/** Adds a plot to the end of the stack. */

--- a/ij/gui/Toolbar.java
+++ b/ij/gui/Toolbar.java
@@ -497,7 +497,6 @@ public class Toolbar extends Canvas implements MouseListener, MouseMotionListene
 		if (null==g) return;
 		icon = icons[tool];
 		if (icon==null) return;
-		this.icon = icon;
 		int x1, y1, x2, y2;
 		pc = 0;
 		if (icon.trim().startsWith("icon:")) {

--- a/ij/plugin/ScreenGrabber.java
+++ b/ij/plugin/ScreenGrabber.java
@@ -1,13 +1,17 @@
 package ij.plugin;
+
 import ij.*;
 import ij.process.*;
 import ij.gui.*;
 import java.awt.*;
+import java.awt.image.MultiResolutionImage;
 
-/** This plugin implements the Plugins/Utilities/Capture Screen
-    and Plugins/Utilities/Capture Image commands. Note that these
-    commands may not work on Linux if windows translucency or 
-    special effects are enabled in the windows manager. */
+/**
+ * This plugin implements the Plugins/Utilities/Capture Screen and
+ * Plugins/Utilities/Capture Image commands. Note that these commands may not
+ * work on Linux if windows translucency or special effects are enabled in the
+ * windows manager.
+ */
 public class ScreenGrabber implements PlugIn {
 	private static int delay = 10;
 
@@ -19,49 +23,62 @@ public class ScreenGrabber implements PlugIn {
 			imp2 = captureDelayed();
 		else
 			imp2 = captureScreen();
-		if (imp2!=null)
+		if (imp2 != null)
 			imp2.show();
 	}
-	
+
 	private ImagePlus captureDelayed() {
 		GenericDialog gd = new GenericDialog("Delayed Capture");
 		gd.addNumericField("Delay (seconds):", delay, 0);
 		gd.showDialog();
 		if (gd.wasCanceled())
 			return null;
-		int delay = (int)gd.getNextNumber();
-		if (delay<0) return null;
-		if (delay>60) delay=60;
-		for (int i=0; i<delay; i++) {
+		int delay = (int) gd.getNextNumber();
+		if (delay < 0)
+			return null;
+		if (delay > 60)
+			delay = 60;
+		for (int i = 0; i < delay; i++) {
 			IJ.wait(1000);
-			IJ.showStatus("Delayed capture: "+(i+1)+"/"+delay);
-			if (delay>4 && i==delay-2) IJ.beep();
+			IJ.showStatus("Delayed capture: " + (i + 1) + "/" + delay);
+			if (delay > 4 && i == delay - 2)
+				IJ.beep();
 		}
 		return captureScreen();
 	}
 
-    
 	/** Captures the entire screen and returns it as an ImagePlus. */
 	public ImagePlus captureScreen() {
 		ImagePlus imp = null;
+		Image img=null;
 		try {
 			Robot robot = new Robot();
 			Rectangle r = GUI.getScreenBounds(IJ.getInstance()); // screen showing "ImageJ" window
-			Image img = robot.createScreenCapture(r);
-			if (img!=null) imp = new ImagePlus("Screenshot", img);
-		} catch(Exception e) {}
+
+			MultiResolutionImage mImage = robot.createMultiResolutionScreenCapture(r);
+			java.util.List<Image> resolutionVariants = mImage.getResolutionVariants();
+			if (resolutionVariants.size() > 1) {
+				img = resolutionVariants.get(1);
+			} else {
+				img = resolutionVariants.get(0);
+			}
+			if (img != null)
+				imp = new ImagePlus("Screenshot", img);
+		} catch (Exception e) {
+		}
 		return imp;
 	}
 
 	/** Captures the active image window and returns it as an ImagePlus. */
 	public ImagePlus captureImage() {
 		ImagePlus imp = IJ.getImage();
-		if (imp==null) {
+		if (imp == null) {
 			IJ.noImage();
 			return null;
 		}
 		ImageWindow win = imp.getWindow();
-		if (win==null) return null;
+		if (win == null)
+			return null;
 		win.toFront();
 		IJ.wait(500);
 		Point loc = win.getLocation();
@@ -77,9 +94,10 @@ public class ScreenGrabber implements PlugIn {
 		try {
 			Robot robot = new Robot();
 			img = robot.createScreenCapture(r);
-		} catch(Exception e) { }
+		} catch (Exception e) {
+		}
 		ic.hideZoomIndicator(wasHidden);
-		if (img!=null) {
+		if (img != null) {
 			String title = WindowManager.getUniqueName(imp.getTitle());
 			imp2 = new ImagePlus(title, img);
 		}
@@ -87,4 +105,3 @@ public class ScreenGrabber implements PlugIn {
 	}
 
 }
-

--- a/ij/plugin/filter/BackgroundSubtracter.java
+++ b/ij/plugin/filter/BackgroundSubtracter.java
@@ -806,7 +806,6 @@ class RollingBall {
         double smallballradius; // radius of rolling ball (downscaled in x,y and z when image is shrunk)
         int halfWidth;      // distance in x or y from center of patch to any edge (patch "radius")
         
-        this.shrinkFactor = shrinkFactor;
         smallballradius = ballradius/shrinkFactor;
         if (smallballradius<1)
             smallballradius = 1;


### PR DESCRIPTION
Improved the ScreenGrabber class to capture HighResolution images on HighDPI displays (tested on a MacOSX Retina display).
Just minor fixes for warnings. 
- Added close statements for the use of the ZipFile class.
- Added two 'this' operator statements to avoid warnings. 
- Deleted some unused references.
