### PR TITLE
Fixed hyperstack bug in doAverageFloatProjection.

### DIFF
--- a/ij/plugin/ZProjector.java
+++ b/ij/plugin/ZProjector.java
@@ -663,7 +663,7 @@ public class ZProjector implements PlugIn {
 			for (int y=0; y<h; y++) {
 				double sum = 0.0;
 				int count = 0;
-				for (int z=startSlice-1; z<stopSlice; z++) {
+				for (int z=startSlice-1; z<stopSlice; z+=increment) {
 					double value = stack.getVoxel(x, y, z);
 					if (!Double.isNaN(value)) {
 						sum += value;


### PR DESCRIPTION
There was a bug in ZProjector.java that lead to 32-bit hyperstacks not being average-projected correctly (increment was ignored). For other image types (i.e. 16-bit), this was not a problem, because the calculation was not done via `doAverageFloatProjection()`