### PR TITLE
Add support for ignoring progess bar and status line updates.

### DIFF
--- a/ij/IJ.java
+++ b/ij/IJ.java
@@ -53,6 +53,9 @@ public class IJ {
 	public static boolean debugMode;
 	
 	public static boolean hideProcessStackDialog;
+	
+	/** Turn off all status and progress bar updates **/
+	public static boolean ignoreStatusAndProgressUpdates = false;
 	    
     public static final char micronSymbol = '\u00B5';
     public static final char angstromSymbol = '\u00C5';
@@ -143,6 +146,12 @@ public class IJ {
 	public static void setDebugMode(boolean b) {
 		debugMode = b;
 		LogStream.redirectSystem(debugMode);
+	}
+
+	/** Turn on/off ignoring of status and progress bar updates.*/
+	public static void setIgnoreStatusAndProgressUpdates(boolean b) {
+		ignoreStatusAndProgressUpdates = b;
+		LogStream.redirectSystem(ignoreStatusAndProgressUpdates);
 	}
 
 	/** Runs the macro contained in the string <code>macro</code>
@@ -450,6 +459,7 @@ public class IJ {
 		with '!', subsequent showStatus() calls in the current
 		thread (without "!" in the message) are suppressed. */
 	public static void showStatus(String s) {
+		if (ignoreStatusAndProgressUpdates) return;
 		if ((Interpreter.getInstance()==null&&statusBarThread==null)
 		|| (statusBarThread!=null&&Thread.currentThread()!=statusBarThread))
 			protectStatusBar(false);
@@ -474,6 +484,7 @@ public class IJ {
 	 * See: http://wsr.imagej.net/macros/FlashingStatusMessages.txt
 	*/ 
 	public static void showStatus(String message, String options) {
+		if (ignoreStatusAndProgressUpdates) return;
 		showStatus(message);
 		if (options==null)
 			return;
@@ -772,6 +783,7 @@ public class IJ {
     updated only if more than 90 ms have passes since the last call. Does nothing 
 	if the ImageJ window is not present. */
 	public static void showProgress(double progress) {
+		if (ignoreStatusAndProgressUpdates) return;
 		if (progressBar!=null) progressBar.show(progress, false);
 	}
 
@@ -783,6 +795,7 @@ public class IJ {
      * 'currentIndex' is negative (example: Plugins/Utilities/Benchmark).
     */
     public static void showProgress(int currentIndex, int finalIndex) {
+    	if (ignoreStatusAndProgressUpdates) return;
 		if (progressBar!=null) {
 			progressBar.show(currentIndex, finalIndex);
 			if (currentIndex==finalIndex)


### PR DESCRIPTION
I added a flag for ignoring all subsequent status line and progress bar updates in `IJ.java`.

The motivation was that currently, when calling/running any plugin A from within another plugin B, and A writes its own updates to the status line or progress bar, there can be the following issues:

- If B wants to call A in parallel, the status updates of A will mess up the progress bar and status line completely.
- If B wants to display a total status of some task that involves repeatedly calling A, the progress and status bar display of A will get in the way, even if B does not employ parallelization.

I tried "protecting" the status bar by posting messages beginning with `!`, but this will get deactivated across threads. When it comes to the progress bar, I tried to call the `setBatchMode(...)` method of the main ProgressBar instance manually, but this will get deactivated if any thread was calling `IJ.showProgress(int currentIndex, int lastIndex)` with `currentIndex == lastIndex`.

As a conclusion, there really is no good method of preventing other plugins from cluttering the progress bar and status line, so I thought it would be cleaner to introduce this flag.

