### PR TITLE
Fix for Scaling images corrupts arrow overlays (Issue #125)

### DIFF
--- a/ij/plugin/RoiScaler.java
+++ b/ij/plugin/RoiScaler.java
@@ -98,7 +98,11 @@ public class RoiScaler implements PlugIn {
 		}
 		Roi roi2 = null;
 		if (type==Roi.LINE)
-			roi2 = new Line(poly.xpoints[0], poly.ypoints[0], poly.xpoints[1], poly.ypoints[1]);
+			if (roi instanceof Arrow){
+				roi2 = new Arrow(poly.xpoints[0], poly.ypoints[0], poly.xpoints[1], poly.ypoints[1]);
+			}else if(roi instanceof Line){
+				roi2 = new Line(poly.xpoints[0], poly.ypoints[0], poly.xpoints[1], poly.ypoints[1]);
+			}
 		else if (type==Roi.POINT)
 			roi2 = new PointRoi(poly.xpoints, poly.ypoints,poly.npoints);
 		else {

--- a/ij/plugin/RoiScaler.java
+++ b/ij/plugin/RoiScaler.java
@@ -100,7 +100,7 @@ public class RoiScaler implements PlugIn {
 		if (type==Roi.LINE)
 			if (roi instanceof Arrow){
 				roi2 = new Arrow(poly.xpoints[0], poly.ypoints[0], poly.xpoints[1], poly.ypoints[1]);
-			}else if(roi instanceof Line){
+			}else {
 				roi2 = new Line(poly.xpoints[0], poly.ypoints[0], poly.xpoints[1], poly.ypoints[1]);
 			}
 		else if (type==Roi.POINT)


### PR DESCRIPTION
The scale method of RoiScaler.java was originally not checking whether Line Roi's were subclass Arrow or not. Thus any rescaled Arrow was being changed to standard lines. This adds a simple instanceof if statement check for Line type Roi's to see if the new rescaled Roi should be declared as a new Line or Arrow subclass. Original problem description: https://github.com/imagej/ImageJ/issues/125