### PR TITLE
Added check for MSR files in ij.io.Opener.getFileType()

### DIFF
--- a/ij/io/Opener.java
+++ b/ij/io/Opener.java
@@ -1300,7 +1300,11 @@ public class Opener {
 		
 		int b0=buf[0]&255, b1=buf[1]&255, b2=buf[2]&255, b3=buf[3]&255;
 		//IJ.log("getFileType: "+ name+" "+b0+" "+b1+" "+b2+" "+b3);
-		
+
+		// ImspectorPro MSR
+		if (name.endsWith(".msr")||name.endsWith(".MSR"))
+			return UNKNOWN; // Opens with Bio-formats plugin
+
 		 // Combined TIFF and DICOM created by GE Senographe scanners
 		if (buf[128]==68 && buf[129]==73 && buf[130]==67 && buf[131]==77
 		&& ((b0==73 && b1==73)||(b0==77 && b1==77)))


### PR DESCRIPTION
ImspectorPro MSR files lack proper public documentation and appear to have a header with "CProperty" or "CDataStack" in the first 30 bytes, followed by metadata. Given the random structure of the header and having metadata at offset 128, some files are interpreted as DICOM files and ImageJ tries to open them as such. The majority of our files start with 0x080000.

I added a small check for the file extension. If the file extension is MSR, getFileType will return unknown and Bio-Formats can handle the files correctly. I didn't add a check for the magic strings "CProperty" and "CDataStack" because there might be files that have a different string that is unknown so far and Bio-Formats checks for the strings. There shouldn't be any DICOM files that actually have .MSR file extension.