### PR TITLE
Update ImagesToStack.java to retain all overlays when not all images …

### DIFF
--- a/ij/plugin/ImagesToStack.java
+++ b/ij/plugin/ImagesToStack.java
@@ -199,6 +199,15 @@ public class ImagesToStack implements PlugIn {
 						}
 						ip2.insert(ip, xoff, yoff);
 						ip = ip2;
+						Overlay overlay2 = images[i].getOverlay();
+						if (overlay2!=null) {
+							overlay2.translate(xoff, yoff);
+							for (int j=0; j<overlay2.size(); j++) {
+								Roi roi = overlay2.get(j);
+								roi.setPosition(i+1);
+								overlay.add((Roi)roi.clone());
+							}
+						}
 						break;
 					case SCALE_SMALL: case SCALE_LARGE:
 						ip.setInterpolationMethod((bicubic?ImageProcessor.BICUBIC:ImageProcessor.BILINEAR));


### PR DESCRIPTION
…are the same size

Previously it was not possible to combine multiple images of different sizes and overlays into a stack with this function. All but the overlay of the first image was lost when doing this. Now intuitive behaviour is implemented to retain all overlays when using the copy method (center or top-left). Application: e.g. labelled cells (via overlay) in a temporal stack of stitched images that slightly vary in image dimensions over time.