### PR TITLE
The folder opener only used the first FileInfo from a tiffile.

### DIFF
--- a/ij/plugin/FolderOpener.java
+++ b/ij/plugin/FolderOpener.java
@@ -536,15 +536,17 @@ public class FolderOpener implements PlugIn, TextListener {
 				stack.addImage(fi);
 			}
 		} else {
-			FileInfo fi = info[0];
-			if (fi.fileType==FileInfo.RGB48) {
-				for (int slice=1; slice<=3; slice++) {
-					FileInfo fi2 = (FileInfo)fi.clone();
-					fi2.sliceNumber = slice;
-					stack.addImage(fi2);
-				}
-			} else
-				stack.addImage(fi);
+			//This only used the first image!
+			for(FileInfo fi : info) {
+				if (fi.fileType == FileInfo.RGB48) {
+					for (int slice = 1; slice <= 3; slice++) {
+						FileInfo fi2 = (FileInfo) fi.clone();
+						fi2.sliceNumber = slice;
+						stack.addImage(fi2);
+					}
+				} else
+					stack.addImage(fi);
+			}
 		}
 	}
 	


### PR DESCRIPTION
I made a test, but I didn't put it in the source because of the requisite test data. The test data can be created using the code found in issue https://github.com/imagej/ImageJ/issues/242

Here is the test.

```
public class FolderOpenerTest {
    @Test
    public void compareVirtualToNormalStackSize(){
        ImagePlus one = FolderOpener.open("./volumes");
        ImagePlus two = FolderOpener.open("./volumes", "virtual");

        Assert.assertEquals(one.getStack().getSize(), two.getStack().getSize());
    }
}
```

I have two collaborators who have sent me image stacks that break from this bug. One of the collaborators sent data from multiple sources. 