### PR TITLE
Update CommandFinder.java to filter commands matching all words in any order

### DIFF
--- a/ij/plugin/CommandFinder.java
+++ b/ij/plugin/CommandFinder.java
@@ -100,18 +100,22 @@ public class CommandFinder implements PlugIn, ActionListener, WindowListener, Ke
 	}
 
 	protected void populateList(String matchingSubstring) {
-		String substring = matchingSubstring.toLowerCase();
+		String[] words = matchingSubstring.toLowerCase().split("\\s+");  // Split the search string into words
 		ArrayList list = new ArrayList();
-		int count = 0;
 		for (int i = 0; i < commands.length; ++i) {
 			String commandName = commands[i];
 			String command = commandName.toLowerCase();
 			CommandAction ca = (CommandAction) commandsHash.get(commandName);
-			String menuPath = ca.menuLocation;
-			if (menuPath == null)
-				menuPath = "";
-			menuPath = menuPath.toLowerCase();
-			if (command.indexOf(substring) >= 0 || menuPath.indexOf(substring) >= 0) {
+			String menuPath = (ca.menuLocation != null) ? ca.menuLocation.toLowerCase() : "";
+			// Check if all words match either the command or the menu path
+			boolean allWordsMatch = true;
+			for (String word : words) {
+				if (!(command.contains(word) || menuPath.contains(word))) {
+					allWordsMatch = false;
+					break;
+				}
+			}
+			if (allWordsMatch) {
 				String[] row = makeRow(commandName, ca);
 				list.add(row);
 			}


### PR DESCRIPTION
Hello @rasband,

I propose this upgrade for the search functionality in the CommandFinder plugin that I use a lot

Previously, the search filtered commands if the full substring was found in either the command name or the menu path.
Here, it splits the input into individual words and returns commands where all words are found in either the command name or the menu path, in any order. 

This provides more precise and flexible filtering :
![image](https://github.com/user-attachments/assets/da84dfc6-cc87-424b-9931-cdfebcaf6600)

I hope you like it.

Best,
Kevin




