### PR TITLE
Fixing crashes in processes initiated by exec()

### DIFF
--- a/ij/macro/Functions.java
+++ b/ij/macro/Functions.java
@@ -5157,6 +5157,25 @@ public class Functions implements MacroConstants, Measurements {
 		return desc.dispatch(this);
 	}
 
+	void handleProcessBuffers(InputStream... streams){
+		for (int i = 0; i < streams.length; i++) {
+			InputStream is = streams[i];
+			new Thread(new Runnable(){
+                @Override
+                public void run(){
+                    try {
+                        BufferedReader br = new BufferedReader(new InputStreamReader(is));
+                        while (br.readLine() != null)
+                        {}
+                    } catch (IOException ioe)
+                        {
+                        ioe.printStackTrace();  
+                    }
+                }
+            }).start();
+		}
+	}
+
 	String exec() {
 		String[] cmd;
 		StringBuffer sb = new StringBuffer(256);
@@ -5191,14 +5210,20 @@ public class Functions implements MacroConstants, Measurements {
 			Process p = Runtime.getRuntime().exec(cmd);
 			boolean returnImmediately = openingDoc || !waitForCompletion;
 			waitForCompletion = true;
-			if (returnImmediately)
+			if (returnImmediately){
+				handleProcessBuffers(p.getInputStream(), p.getErrorStream()); // empty both buffers
 				return null;
-			reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+			} else {
+				handleProcessBuffers(p.getErrorStream()); // empty only unused ErrorStream buffer
+			}
+			reader = new BufferedReader(new InputStreamReader(p.getInputStream())); // notice that this function will discard all process error output
 			String line; int count=1;
 			while ((line=reader.readLine())!=null)  {
         		sb.append(line+"\n");
-        		if (count++==1&&line.startsWith("Microsoft Windows"))
-        			break; // user probably ran 'cmd' without /c option
+        		if (count++==1&&line.startsWith("Microsoft Windows")){
+					handleProcessBuffers(p.getInputStream()); // must empty the InputStream buffer anyway
+					break; // user probably ran 'cmd' without /c option
+				}
         	}
 		} catch (Exception e) {
     		sb.append(e.getMessage()+"\n");


### PR DESCRIPTION
Fixing [this issue](https://github.com/imagej/ImageJ/issues/265).

[Oracle documentation](https://docs.oracle.com/javase/8/docs/api/java/lang/Process.html) explains why the processes seem to crash randomly:

> Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.

This is further explained in [this excellent article](https://web.archive.org/web/20080605235751/http://www.javaworld.com/javaworld/jw-12-2000/jw-1229-traps.html?page=1), from which I drew inspiration.

To reproduce the error, set `setOption("WaitForCompletion", true)` and use exec() to run a program that generates a large amount of output to stderr. Observe the process crash. I tested this with [ffplay](https://ffmpeg.org/ffplay.html) (from FFmpeg), which, for some reason, outputs exclusively to that stream.

```
setOption("WaitForCompletion", true);
exec("ffplay -i \"F:\\test videos\\BigBuckBunny.mp4\"");
```

TL;DR
**We need to empty the buffers; otherwise, they will fill up and crash the process.**