### PR TITLE
Filter3D for Hyperstacks

### DIFF
--- a/ij/process/StackProcessor.java
+++ b/ij/process/StackProcessor.java
@@ -195,11 +195,9 @@ public class StackProcessor {
 	    int inc = nSlices/20;
 	    if (inc<1) inc = 1;
 	    boolean stackSource = srcIp==null;
-	    int div=nSlices;
-	    if(stackSource) div=srcStack.getSize();
 	    for (int i=1; i<=nSlices; i++) {
 	    	if (stackSource)
-	    		srcIp = srcStack.getProcessor(((i-1)%div)+1);
+	    		srcIp = srcStack.getProcessor(i);
  	    	ImageProcessor dstIp = stack.getProcessor(i);
 	    	dstIp.copyBits(srcIp, xloc, yloc, mode);
 			if ((i%inc) == 0) IJ.showProgress((double)i/nSlices);


### PR DESCRIPTION
Added a StackProcessor.filter3d function to apply to multidimensional hyperstacks, and modified ij.plugin.Filters3D to handle multidimensional hyperstacks. Added options to only perform the 3D filters on a single frame or all frames, and on only a single channel or all channels. Kept original functions, so non-hyperstacks can use the same functions.  Default for hyperstacks is also to run on every channel in every frame.